### PR TITLE
Update `HttpService[F].apply` docs

### DIFF
--- a/core/src/main/scala/org/http4s/HttpService.scala
+++ b/core/src/main/scala/org/http4s/HttpService.scala
@@ -14,9 +14,8 @@ object HttpService extends Serializable {
   def lift[F[_]: Functor](f: Request[F] => F[Response[F]]): HttpService[F] =
     Kleisli(f.andThen(OptionT.liftF(_)))
 
-  /** Lifts a partial function to an `HttpService`. Responds with
-    * [[org.http4s.Response.notFoundFor]], which generates a 404, for any request
-    * where `pf` is not defined.
+  /** Lifts a partial function to an `HttpService`.
+    * Responds with `OptionT.none` for any request where `pf` is not defined.
     */
   def apply[F[_]](pf: PartialFunction[Request[F], F[Response[F]]])(
       implicit F: Applicative[F]): HttpService[F] =


### PR DESCRIPTION
It seems that the docs for the `apply` is outdated, as there is no `org.http4s.Response.notFoundFor` anymore.
I suggest replacing it with the `OptionT.none` response.